### PR TITLE
Refactor router push path for creating evidence in reports page

### DIFF
--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -56,7 +56,7 @@ const Page: React.FC = () => {
   }, [reports, userReports]);
 
   const handleButtonClick = () => {
-    router.push('/create-evidence');
+    router.push('/reports/create');
   };
 
   return (


### PR DESCRIPTION
This pull request includes a small change to the `src/app/reports/page.tsx` file. The change updates the navigation path when a button is clicked.

* [`src/app/reports/page.tsx`](diffhunk://#diff-a1ddba5b1d93fe8db8d4d77ccebb062743b0e59507d26e8b61e1c25562e5cd87L59-R59): Changed the route in the `handleButtonClick` function from `/create-evidence` to `/reports/create`.