### PR TITLE
Added share route functionality

### DIFF
--- a/src/app/navigation/layout.tsx
+++ b/src/app/navigation/layout.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import React, { Suspense } from 'react';
+
+const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      {children}
+    </Suspense>
+  );
+};
+
+export default Layout;

--- a/src/app/navigation/page.tsx
+++ b/src/app/navigation/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useContext } from 'react';
+import { useSearchParams } from 'next/navigation';
 import AutoComplete from '../AutoComplete';
 import 'leaflet/dist/leaflet.css';
 import '../globals.css';
@@ -37,6 +38,37 @@ const NavigationComponent: React.FC = () => {
       setEndLocation(newEnd);
     }
   }, [selectedItinerary]);
+
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    
+    const startLat = searchParams.get('startLat');
+    const startLon = searchParams.get('startLon');
+    const startName = searchParams.get('startName');
+    const startDisplayName = searchParams.get('startDisplayName');
+    const endLat = searchParams.get('endLat');
+    const endLon = searchParams.get('endLon');
+    const endName = searchParams.get('endName');
+    const endDisplayName = searchParams.get('endDisplayName');
+
+    if (startLat && startLon && startName && startDisplayName) {
+      setStartLocation({
+        lat: parseFloat(startLat),
+        lon: parseFloat(startLon),
+        name: startName,
+        display_name: startDisplayName,
+      });
+    }
+    if (endLat && endLon && endName && endDisplayName) {
+      setEndLocation({
+        lat: parseFloat(endLat),
+        lon: parseFloat(endLon),
+        name: endName,
+        display_name: endDisplayName,
+      });
+    }
+  }, [searchParams]);
 
   const handleSelectStart = (location: { lat: number; lon: number; display_name: string } | null) => {
     if (location) {


### PR DESCRIPTION
This pull request introduces several enhancements to the navigation and search history pages, primarily focusing on adding URL parameter handling and a new route-sharing feature.

### Enhancements to Navigation Page:

* **URL Parameter Handling**: Imported `useSearchParams` from `next/navigation` and added a `useEffect` hook to set start and end locations based on URL parameters. (`src/app/navigation/page.tsx`) [[1]](diffhunk://#diff-59be0d278e9293e4a790b190e56f30f67881600ecf80e527a6a8e2cecfd6e86dR4) [[2]](diffhunk://#diff-59be0d278e9293e4a790b190e56f30f67881600ecf80e527a6a8e2cecfd6e86dR42-R72)

### Enhancements to Search History Page:

* **Route Sharing Feature**: 
  * Added `ShareIcon` import and implemented a `generateShareUrl` function to create a shareable URL for saved routes. (`src/app/search-history/page.tsx`) [[1]](diffhunk://#diff-8b0f6d14c9c453611ee436b33cf13bdd2520b9eb101bbb0a34ec7a3f5a4069b3L1-R1) [[2]](diffhunk://#diff-8b0f6d14c9c453611ee436b33cf13bdd2520b9eb101bbb0a34ec7a3f5a4069b3R11) [[3]](diffhunk://#diff-8b0f6d14c9c453611ee436b33cf13bdd2520b9eb101bbb0a34ec7a3f5a4069b3R46-L48)
  * Added a `shareRoute` function to use the Web Share API for sharing route details or copying them to the clipboard as a fallback. (`src/app/search-history/page.tsx`)
  * Added a "Compartir" button to the UI for sharing routes. (`src/app/search-history/page.tsx`)

### Code Style Improvements:

* **Consistency in String Literals**: Changed the string literal style from double quotes to single quotes for consistency. (`src/app/search-history/page.tsx`)
* **Removed Unnecessary Comments**: Cleaned up comments to improve code readability. (`src/app/search-history/page.tsx`)