### PR TITLE
Add download functionality and share menu to saved routes

### DIFF
--- a/src/app/search-history/page.tsx
+++ b/src/app/search-history/page.tsx
@@ -8,13 +8,22 @@ import TrainIcon from "@mui/icons-material/Train";
 import DirectionsBoatIcon from "@mui/icons-material/DirectionsBoat";
 import DeleteIcon from "@mui/icons-material/Delete";
 import MapIcon from "@mui/icons-material/Map";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
 import ShareIcon from "@mui/icons-material/Share";
-import { Button, ToggleButton, ToggleButtonGroup } from "@mui/material";
+import {
+  Button,
+  IconButton,
+  Menu,
+  MenuItem,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "@mui/material";
 import Layout from "@/components/Layout";
 import { useRouter } from "next/navigation";
 import { SelectedItineraryContext } from "@/contexts/SelectedItineraryContext";
 import { Itinerary } from "@/types/map";
 import MostFrequentedRoutes from "@/components/MostFrequentedRoutes";
+import DownloadRouteButton from "@/components/DownloadRouteButton";
 
 const SavedRoutesComponent: React.FC = () => {
   const [savedRoutes, setSavedRoutes] = useState<Itinerary[]>([]);
@@ -22,6 +31,8 @@ const SavedRoutesComponent: React.FC = () => {
     SelectedItineraryContext
   );
   const router = useRouter();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [menuIndex, setMenuIndex] = useState<number | null>(null);
 
   useEffect(() => {
     const existingRoutes = JSON.parse(
@@ -81,12 +92,24 @@ const SavedRoutesComponent: React.FC = () => {
     if (navigator.share) {
       navigator.share(shareData).catch(console.error);
     } else {
-      // Fallback for browsers that do not support the Web Share API
       navigator.clipboard.writeText(
         `${shareData.title}\n${shareData.text}\n${shareData.url}`
       );
       alert("Detalles de la ruta copiados al portapapeles.");
     }
+  };
+
+  const handleMenuClick = (
+    event: React.MouseEvent<HTMLElement>,
+    index: number
+  ) => {
+    setAnchorEl(event.currentTarget);
+    setMenuIndex(index);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setMenuIndex(null);
   };
 
   return (
@@ -155,15 +178,34 @@ const SavedRoutesComponent: React.FC = () => {
                     >
                       Mapear Ruta
                     </Button>
-                    <Button
-                      variant="contained"
-                      color="primary"
-                      startIcon={<ShareIcon />}
-                      onClick={() => shareRoute(itinerary)}
-                      className="w-1/3 bg-green-500 hover:bg-green-600"
+                    <IconButton
+                      aria-label="more"
+                      aria-controls="long-menu"
+                      aria-haspopup="true"
+                      onClick={(event) => handleMenuClick(event, index)}
+                      className="w-1/3"
                     >
-                      Compartir
-                    </Button>
+                      <MoreVertIcon />
+                    </IconButton>
+                    <Menu
+                      anchorEl={anchorEl}
+                      keepMounted
+                      open={Boolean(anchorEl) && menuIndex === index}
+                      onClose={handleMenuClose}
+                    >
+                      <MenuItem
+                        onClick={() => {
+                          shareRoute(itinerary);
+                          handleMenuClose();
+                        }}
+                      >
+                        <ShareIcon className="mr-2 text-blue-500" />
+                        <span className="text-blue-500">Compartir</span>
+                      </MenuItem>
+                      <MenuItem onClick={handleMenuClose}>
+                        <DownloadRouteButton itinerary={itinerary} />
+                      </MenuItem>
+                    </Menu>
                   </div>
                 </div>
                 <div className="mt-4 flex flex-wrap items-center space-x-4 md:space-x-6">

--- a/src/components/DownloadRouteButton.tsx
+++ b/src/components/DownloadRouteButton.tsx
@@ -1,0 +1,34 @@
+// FILE: DownloadRouteButton.tsx
+import React from "react";
+import { Button } from "@mui/material";
+import DownloadIcon from "@mui/icons-material/Download";
+import { Itinerary } from "@/types/map";
+
+interface DownloadRouteButtonProps {
+  itinerary: Itinerary;
+}
+
+const DownloadRouteButton: React.FC<DownloadRouteButtonProps> = ({ itinerary }) => {
+  const downloadRoute = () => {
+    const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(itinerary));
+    const downloadAnchorNode = document.createElement("a");
+    downloadAnchorNode.setAttribute("href", dataStr);
+    downloadAnchorNode.setAttribute("download", `route_${itinerary.startNameIti}_to_${itinerary.endNameIti}.json`);
+    document.body.appendChild(downloadAnchorNode);
+    downloadAnchorNode.click();
+    downloadAnchorNode.remove();
+  };
+
+  return (
+    <Button
+      variant="text"
+      startIcon={<DownloadIcon />}
+      onClick={downloadRoute}
+      className="w-full text-blue-500 hover:bg-blue-100"
+    >
+      Descargar
+    </Button>
+  );
+};
+
+export default DownloadRouteButton;


### PR DESCRIPTION
This pull request enhances the `SavedRoutesComponent` in `src/app/search-history/page.tsx` by adding a new menu for route options and introducing a `DownloadRouteButton` component for downloading route details. The changes improve the user interface and functionality for managing saved routes.

### Enhancements to SavedRoutesComponent:

* Added a new menu for route options using `IconButton`, `Menu`, and `MenuItem` components. This menu allows users to share or download route details. [[1]](diffhunk://#diff-8b0f6d14c9c453611ee436b33cf13bdd2520b9eb101bbb0a34ec7a3f5a4069b3R11-R35) [[2]](diffhunk://#diff-8b0f6d14c9c453611ee436b33cf13bdd2520b9eb101bbb0a34ec7a3f5a4069b3L84-R114) [[3]](diffhunk://#diff-8b0f6d14c9c453611ee436b33cf13bdd2520b9eb101bbb0a34ec7a3f5a4069b3L158-R208)
* Introduced state management for the menu (`anchorEl` and `menuIndex`) to handle menu interactions.

### New DownloadRouteButton Component:

* Created `DownloadRouteButton.tsx` which includes a button to download route details as a JSON file. This component is integrated into the new menu in `SavedRoutesComponent`.