### PR TITLE
Allow admin role access to supervisor components and routes

### DIFF
--- a/src/app/FooterComponent.tsx
+++ b/src/app/FooterComponent.tsx
@@ -86,7 +86,7 @@ const FooterComponent: React.FC = () => {
         </>
       )}
 
-      {role === "supervisor" && (
+      {role === "supervisor" || role === "admin" && (
         <>
           <div className="flex-1 relative">
             <button

--- a/src/app/supervisor/layout.tsx
+++ b/src/app/supervisor/layout.tsx
@@ -10,12 +10,12 @@ const SupervisorLayout = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
 
   useEffect(() => {
-    if (role !== "supervisor") {
-      router.push("/"); // Redirect to home page if not a supervisor
+    if (role !== "supervisor" && role !== "admin") {
+      router.push("/"); // Redirect to home page if not a supervisor or admin
     }
   }, [role, router]);
 
-  if (role !== "supervisor") {
+  if (role !== "supervisor" && role !== "admin") {
     return null; // Render nothing while redirecting
   }
 

--- a/src/app/supervisor/page.tsx
+++ b/src/app/supervisor/page.tsx
@@ -17,7 +17,7 @@ const Page = () => {
     return null; // Render nothing on the server
   }
 
-  if (role !== 'supervisor') {
+  if (role !== 'supervisor' && role !== 'admin') {
     return null; // Render nothing if not a supervisor
   }
 


### PR DESCRIPTION
This pull request includes changes to the `FooterComponent`, `supervisor/layout.tsx`, and `supervisor/page.tsx` files to extend admin access and ensure proper redirection for users with the "admin" role in addition to the "supervisor" role.

Changes to extend admin access:

* [`src/app/FooterComponent.tsx`](diffhunk://#diff-037c247549cb72429ea9593bb9368adb47c0356e24bfbb3aaa67607c83b155d4L89-R89): Modified the condition to display certain elements for users with the "supervisor" or "admin" role.

* [`src/app/supervisor/layout.tsx`](diffhunk://#diff-b4a646025b1c383f1b9de497a18f229e65f78cb8b058cff62488cb2ca4bd2562L13-R18): Updated the redirection logic to include the "admin" role, ensuring that users who are not supervisors or admins are redirected to the home page.

* [`src/app/supervisor/page.tsx`](diffhunk://#diff-112d7f9617ff021f50e5c5619aab25750159b165e7c63f5a431761b1c117f2b3L20-R20): Adjusted the conditional rendering to include the "admin" role, ensuring that only supervisors or admins can view the page content.