### PR TITLE
Remove unused user authentication logic from RootLayout component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import "leaflet/dist/leaflet.css";
 import { ReportsProvider } from "@/contexts/ReportsContext";
 import { SelectedItineraryProvider } from "@/contexts/SelectedItineraryContext";
 import { RoleProvider } from "@/contexts/RoleContext";
-import { Knock } from "@knocklabs/node";
-import { useEffect, useState } from "react";
-import useUserStore from "@/stores/useUser";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -18,39 +14,6 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-
-  const [storedEmail, setStoredEmail] = useState<string | null>(null);
-  const { userDetails, fetchUserDetails } = useUserStore();
-
-  useEffect(() => {
-    const email = localStorage.getItem('email');
-    if (email) {
-      setStoredEmail(email);
-      fetchUserDetails(email);
-    } else {
-      console.error("Email not found in localStorage");
-      setStoredEmail("iespinosas1700@alumno.ipn.mx");
-    }
-  }, [fetchUserDetails]);
-
-  useEffect(() => {
-    if (storedEmail) {
-      const knockClient = new Knock(process.env.NEXT_PUBLIC_KNOCK_SECRET_API_KEY);
-      knockClient.users.identify(storedEmail.toString(), {
-        email: storedEmail ?? undefined,
-        name: userDetails?.name ?? undefined,
-      }).then(knockUser => {
-        console.log(knockUser);
-        console.log(userDetails);
-      }).catch(error => {
-        console.error("Error identifying user with Knock:", error);
-      });
-    }
-  }, [storedEmail, userDetails]);
-
-  if (!storedEmail) {
-    return <div>Loading...</div>;
-  }
 
   return (
     <html lang="en" className={inter.className}>


### PR DESCRIPTION
This pull request includes significant changes to the `src/app/layout.tsx` file, primarily focusing on removing unused imports and redundant user authentication logic. The most important changes are outlined below:

### Code Cleanup:

* Removed unused imports such as `Metadata`, `Knock`, `useEffect`, `useState`, and `useUserStore` from `src/app/layout.tsx`.

### Simplification of User Authentication Logic:

* Removed the state management and side effects related to fetching and storing user details, including the initialization of the `Knock` client and user identification logic. This simplifies the `RootLayout` component by eliminating unnecessary complexity.