### PR TITLE
Add supervisor

### DIFF
--- a/src/app/api/supervisor/sign-up/route.ts
+++ b/src/app/api/supervisor/sign-up/route.ts
@@ -2,11 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
   try {
-    const { email, sup, admin, line, station } = await req.json();
+    const { email, line, station } = await req.json();
 
-    console.log(email, sup, admin, line, station);
+    const admin = '0000000000';
 
-    if (!email || !sup || !admin || line === undefined || station === undefined) {
+    if (!email || !admin || line === undefined || station === undefined) {
       return NextResponse.json(
         {
           timestamp: new Date().toISOString(),
@@ -51,7 +51,6 @@ export async function POST(req: NextRequest) {
 
     // Create supervisor
     const supervisorData = {
-      sup,
       user: userId,
       admin,
       line,

--- a/src/components/admin/AdminSupervisorForm.tsx
+++ b/src/components/admin/AdminSupervisorForm.tsx
@@ -5,18 +5,17 @@ import { useRouter } from 'next/navigation';
 import { IconButton } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useLinesStations } from '@/stores/LinesStationsContext';
+import { Station } from '@/types';
 
 const AdminSupervisorForm = () => {
   const [formData, setFormData] = useState({
     email: '',
-    sup: '',
-    admin: '',
     line: 0,
     station: 0,
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [filteredStations, setFilteredStations] = useState<{ id: number; name: string; line: number }[]>([]);
+  const [filteredStations, setFilteredStations] = useState<Station[]>([]);
   const router = useRouter();
   const { lines, stations } = useLinesStations();
 
@@ -61,9 +60,7 @@ const AdminSupervisorForm = () => {
       // Create supervisor
       const supervisorData = {
         email: formData.email,
-        sup: formData.sup,
         user: userId,
-        admin: formData.admin,
         line: formData.line,
         station: formData.station,
       };
@@ -111,28 +108,6 @@ const AdminSupervisorForm = () => {
             type="email"
             name="email"
             value={formData.email}
-            onChange={handleChange}
-            className="w-full px-3 py-2 border rounded-lg"
-            required
-          />
-        </div>
-        <div className="mb-4">
-          <label className="block text-gray-700">ID del Supervisor</label>
-          <input
-            type="text"
-            name="sup"
-            value={formData.sup}
-            onChange={handleChange}
-            className="w-full px-3 py-2 border rounded-lg"
-            required
-          />
-        </div>
-        <div className="mb-4">
-          <label className="block text-gray-700">Administrador</label>
-          <input
-            type="text"
-            name="admin"
-            value={formData.admin}
             onChange={handleChange}
             className="w-full px-3 py-2 border rounded-lg"
             required


### PR DESCRIPTION
This pull request includes several changes to the supervisor sign-up API and the admin supervisor form. The main changes involve removing the `sup` and `admin` fields from both the backend and frontend code.

Changes to `src/app/api/supervisor/sign-up/route.ts`:
<img width="1468" alt="Screenshot 2024-12-01 at 9 01 20 a m" src="https://github.com/user-attachments/assets/f0c36084-d9ed-4b2d-93b5-6cce8c0c2cfb">

* Removed `sup` field from the request body and the supervisor creation logic. [[1]](diffhunk://#diff-810c968b875090f131c8f8b7b8d122dd905b8d493ed6484a507bf0ed45c5e2b7L5-R9) [[2]](diffhunk://#diff-810c968b875090f131c8f8b7b8d122dd905b8d493ed6484a507bf0ed45c5e2b7L54)
* Set a default value for the `admin` field in the request body and adjusted the validation logic accordingly.

Changes to `src/components/admin/AdminSupervisorForm.tsx`:

* Removed `sup` and `admin` fields from the form state and the supervisor creation logic. [[1]](diffhunk://#diff-a5111e67da37cb28bc4047603203d52f88d617399ec0e93572a46a9a1f0a18e3R8-R18) [[2]](diffhunk://#diff-a5111e67da37cb28bc4047603203d52f88d617399ec0e93572a46a9a1f0a18e3L64-L66)
* Deleted the input fields for `sup` and `admin` from the form UI.