### PR TITLE
Enhance EvidenceDetails component to display line and station names w…

### DIFF
--- a/src/app/reports/details/page.tsx
+++ b/src/app/reports/details/page.tsx
@@ -5,11 +5,12 @@ import { useReports } from "@/contexts/ReportsContext";
 import { useRouter } from "next/navigation";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { useRole } from "@/contexts/RoleContext";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Status } from "@/types/register";
 import ConfirmModal from "@/components/ConfirmModal";
 import MapWithMarker from "@/components/MapWithMarker"; // Importa el componente del mapa
 import { Knock } from "@knocklabs/node";
+import { useLinesStations } from "@/stores/LinesStationsContext";
 
 const EvidenceDetails: React.FC = () => {
   const { selectedReport, setSelectedReport, updateReport } = useReports();
@@ -17,6 +18,7 @@ const EvidenceDetails: React.FC = () => {
   const { role } = useRole();
   const [newStatus, setNewStatus] = useState<Status | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const { lines, stations, getFirstAndLastStations } = useLinesStations();
 
   const knockApiKey = process.env.NEXT_PUBLIC_KNOCK_SECRET_API_KEY;
 
@@ -118,8 +120,11 @@ const EvidenceDetails: React.FC = () => {
     return <div>Loading...</div>;
   }
 
-  const { body, date, line, route, station, status, transport, time, x, y } =
-    selectedReport;
+  const { body, date, line: lineId, route, station: stationId, status, transport, time, x, y } = selectedReport;
+
+  const line = lines.find(line => line.id === lineId);
+  const station = stations.find(station => station.id === stationId);
+  const { firstStation, lastStation } = getFirstAndLastStations(lineId);
 
   return (
     <Layout>
@@ -147,7 +152,7 @@ const EvidenceDetails: React.FC = () => {
           </div>
           <div className="flex flex-col sm:flex-row justify-between">
             <span className="font-semibold">Línea:</span>
-            <span>{line}</span>
+            <span>{line?.name} de {firstStation?.name} a {lastStation?.name}</span>
           </div>
           <div className="flex flex-col sm:flex-row justify-between">
             <span className="font-semibold">Ruta:</span>
@@ -155,7 +160,7 @@ const EvidenceDetails: React.FC = () => {
           </div>
           <div className="flex flex-col sm:flex-row justify-between">
             <span className="font-semibold">Estación:</span>
-            <span>{station}</span>
+            <span>{station?.name}</span>
           </div>
           <div className="flex flex-col sm:flex-row justify-between">
             <span className="font-semibold">Estado:</span>


### PR DESCRIPTION
This pull request includes several updates to the `src/app/reports/details/page.tsx` file to enhance the functionality and display of report details. The most important changes involve importing additional hooks and updating how line and station information is retrieved and displayed.

<img width="1470" alt="Screenshot 2024-12-01 at 10 26 40 a m" src="https://github.com/user-attachments/assets/766edecc-21b7-4f30-9c7c-ab1c74e5b590">


### Enhancements to report details functionality:

* [`src/app/reports/details/page.tsx`](diffhunk://#diff-a8495cfc0a2de51f3ff632cdd25c57209f502f056c832e2d165a3a737969800fL8-R21): Added `useEffect` and `useLinesStations` imports to manage side effects and access line and station data.
* [`src/app/reports/details/page.tsx`](diffhunk://#diff-a8495cfc0a2de51f3ff632cdd25c57209f502f056c832e2d165a3a737969800fL121-R127): Updated the `EvidenceDetails` component to extract `lineId` and `stationId` from `selectedReport` and find the corresponding line and station objects.

### Improvements to report details display:

* [`src/app/reports/details/page.tsx`](diffhunk://#diff-a8495cfc0a2de51f3ff632cdd25c57209f502f056c832e2d165a3a737969800fL150-R163): Enhanced the display of the line information to show the line name along with the first and last stations.
* [`src/app/reports/details/page.tsx`](diffhunk://#diff-a8495cfc0a2de51f3ff632cdd25c57209f502f056c832e2d165a3a737969800fL150-R163): Updated the station display to show the station name instead of the station ID.
