### PR TITLE
Update react-leaflet to version 5.0.0-rc.1 in package.json and packag…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "nookies": "^2.5.2",
         "react": "^18",
         "react-dom": "^18",
-        "react-leaflet": "^4.2.1",
+        "react-leaflet": "^5.0.0-rc.1",
         "sharp": "^0.33.5",
         "zustand": "^5.0.1"
       },
@@ -3601,13 +3601,14 @@
       }
     },
     "node_modules/@react-leaflet/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "version": "3.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0-rc.1.tgz",
+      "integrity": "sha512-1Z9Cc49G8vN7q5uRZjUbE4p+voddW1ARrYiPOGphlcsODhKhfJLQSBN7YNxi/+IQrN5qALPVQQLiovgZKT/kyQ==",
+      "license": "Hippocratic-2.1",
       "peerDependencies": {
         "leaflet": "^1.9.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "rc",
+        "react-dom": "rc"
       }
     },
     "node_modules/@react-stately/utils": {
@@ -8831,16 +8832,17 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-leaflet": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
-      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "version": "5.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0-rc.1.tgz",
+      "integrity": "sha512-pqxGH/rgUQAUuimnIt/6xLeNAcWymM/kxPpm6v1plXMNHd41Iy6i2sYbzsrRVmspXRT0HtuxQc7jWF+FRHyhYg==",
+      "license": "Hippocratic-2.1",
       "dependencies": {
-        "@react-leaflet/core": "^2.1.0"
+        "@react-leaflet/core": "^3.0.0-rc.1"
       },
       "peerDependencies": {
         "leaflet": "^1.9.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "rc",
+        "react-dom": "rc"
       }
     },
     "node_modules/react-popper": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "nookies": "^2.5.2",
     "react": "^18",
     "react-dom": "^18",
-    "react-leaflet": "^4.2.1",
+    "react-leaflet": "^5.0.0-rc.1",
     "sharp": "^0.33.5",
     "zustand": "^5.0.1"
   },


### PR DESCRIPTION
This pull request includes an update to the `package.json` file. The change updates the version of the `react-leaflet` package to a release candidate version.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R28): Updated `react-leaflet` from version `^4.2.1` to `^5.0.0-rc.1`.…e-lock.json

https://github.com/PaulLeCam/react-leaflet/issues/1133