### PR TITLE
refactor MostVisited component to aggregate and display unique transi…

### DIFF
--- a/src/components/MostVisited.tsx
+++ b/src/components/MostVisited.tsx
@@ -1,4 +1,3 @@
-// FILE: components/MostVisited.tsx
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -13,7 +12,27 @@ const MostVisited: React.FC = () => {
 
   useEffect(() => {
     const savedRoutes = JSON.parse(localStorage.getItem('savedRoutes') || '[]');
-    const lines = savedRoutes.filter((route: any) => route.type === 'line');
+    console.log(savedRoutes);
+
+    const lines = savedRoutes.flatMap((route: any) =>
+      route.legs
+        .filter((leg: any) => leg.mode !== 'WALK')
+        .map((leg: any) => ({
+          agency: leg.route?.agency?.name || 'Unknown',
+          longName: leg.route?.longName || 'Unknown',
+          shortName: leg.route?.shortName || 'Unknown'
+        }))
+    );
+
+    const lineFrequency = lines.reduce((acc: any, line: any) => {
+      const key = `${line.agency}-${line.longName}-${line.shortName}`;
+      acc[key] = acc[key] || { ...line, frequency: 0 };
+      acc[key].frequency += 1;
+      return acc;
+    }, {});
+
+    const uniqueLines = Object.keys(lineFrequency).map(key => lineFrequency[key]);
+
     const stations = savedRoutes.flatMap((route: any) => 
       route.legs.map((leg: any) => ({
         name: leg.to.name,
@@ -33,7 +52,7 @@ const MostVisited: React.FC = () => {
       agency: stationFrequency[station].agency
     }));
 
-    setMostVisited({ lines, stations: uniqueStations });
+    setMostVisited({ lines: uniqueLines, stations: uniqueStations });
   }, []);
 
   const handleBackClick = () => {
@@ -79,7 +98,7 @@ const MostVisited: React.FC = () => {
                 {mostVisited.lines.map((line, index) => (
                   <li key={index} className="bg-white p-4 rounded-lg shadow-md hover:shadow-lg transition-shadow">
                     <div className="flex items-center justify-between">
-                      <span>{line.startNameIti} - {line.endNameIti}</span>
+                      <span>{line.agency} {line.shortName}: {line.longName} </span>
                       <span className="text-sm text-gray-500">Frecuencia: {line.frequency}</span>
                     </div>
                   </li>


### PR DESCRIPTION
This pull request includes significant updates to the `MostVisited` component in the `src/components/MostVisited.tsx` file. The changes focus on enhancing the logic for processing saved routes and improving the display of the most visited lines.

Improvements to saved routes processing:
<img width="1463" alt="Screenshot 2024-12-01 at 7 19 49 p m" src="https://github.com/user-attachments/assets/0599d139-26cb-4b01-be03-a1de45e8d278">

* Updated the `useEffect` hook to utilize `flatMap` and `reduce` for processing saved routes, filtering out walking legs, and calculating the frequency of each unique line.
* Modified the `setMostVisited` call to use the newly computed `uniqueLines` for the `lines` property.

Enhancements to line display:

* Adjusted the display of each line in the list to show the agency, short name, and long name, along with the frequency of visits.…t lines with frequency