### PR TITLE
update EvidenceDetails to allow admin role access to status selection

### DIFF
--- a/src/app/reports/details/page.tsx
+++ b/src/app/reports/details/page.tsx
@@ -182,7 +182,7 @@ const EvidenceDetails: React.FC = () => {
             <MapWithMarker lat={x} lon={y} />
           </div>
 
-          {role === "supervisor" && (
+          {(role === "supervisor" || role === "admin") && (
             <div className="mt-6">
               <select
                 value={newStatus || ""}


### PR DESCRIPTION
This pull request includes a change to the `src/app/reports/details/page.tsx` file to expand the visibility of a specific section to both supervisors and admins.

Changes in `src/app/reports/details/page.tsx`:

* Modified the condition in the `EvidenceDetails` component to render a section if the `role` is either "supervisor" or "admin" instead of only "supervisor".