### PR TITLE
fix: update userId in NotificationMenu to a static value

### DIFF
--- a/src/components/notifications/NotificationMenu.tsx
+++ b/src/components/notifications/NotificationMenu.tsx
@@ -29,7 +29,7 @@ const NotificationMenu = () => {
     isClient ? (
     <KnockProvider
       apiKey={process.env.NEXT_PUBLIC_KNOCK_PUBLIC_API_KEY || ""}
-      userId={userDetails?.email || "iespinosas1700@alumno.ipn.mx"}
+      userId={"iespinosas1700@alumno.ipn.mx"}
       i18n={{
         translations: {
           emptyFeedTitle: "No tienes notificaciones aún",


### PR DESCRIPTION
This pull request includes a small change to the `NotificationMenu` component in the `src/components/notifications/NotificationMenu.tsx` file. The change involves setting a static `userId` instead of using the `userDetails?.email` value.

* [`src/components/notifications/NotificationMenu.tsx`](diffhunk://#diff-8ac86eb7ee0c512738738662a871b4fc08b8235564bb6188da09c58076e731f1L32-R32): Changed the `userId` to a static string `"iespinosas1700@alumno.ipn.mx"` instead of using the dynamic `userDetails?.email` value.