### PR TITLE
fix: refactor notification sending to use utility function for incide…

### DIFF
--- a/src/app/reports/details/page.tsx
+++ b/src/app/reports/details/page.tsx
@@ -11,6 +11,7 @@ import ConfirmModal from "@/components/ConfirmModal";
 import MapWithMarker from "@/components/MapWithMarker"; // Importa el componente del mapa
 import { Knock } from "@knocklabs/node";
 import { useLinesStations } from "@/stores/LinesStationsContext";
+import sendKnockNotification, { recipients } from "@/utils/knock/sendNotification";
 
 const EvidenceDetails: React.FC = () => {
   const { selectedReport, setSelectedReport, updateReport } = useReports();
@@ -93,14 +94,9 @@ const EvidenceDetails: React.FC = () => {
         throw new Error("Failed to update station incident");
       }
 
-      await knockNode.workflows.trigger("mts", {
-        recipients: ["iespinosas1700@alumno.ipn.mx", "jangeles1700@alumno.ipn.mx", "aguzman1702@alumno.ipn.mx", "agarciaz1703@alumno.ipn.mx"],
-        data: {
-          incident: {
-            value: incident,
-            station: stationId
-          }
-        }
+      sendKnockNotification(recipients, {
+        value: incident,
+        station: stationId
       });
     } catch (error) {
       console.error("Error updating station incident:", error);


### PR DESCRIPTION
This pull request includes changes to the `src/app/reports/details/page.tsx` file to improve the notification handling and simplify the code. The most important changes include importing a utility function for sending notifications and refactoring the notification trigger logic.

Notification handling improvements:

* [`src/app/reports/details/page.tsx`](diffhunk://#diff-a8495cfc0a2de51f3ff632cdd25c57209f502f056c832e2d165a3a737969800fR14): Imported `sendKnockNotification` and `recipients` from `@/utils/knock/sendNotification` to centralize the notification logic.
* [`src/app/reports/details/page.tsx`](diffhunk://#diff-a8495cfc0a2de51f3ff632cdd25c57209f502f056c832e2d165a3a737969800fL96-L103): Replaced the direct call to `knockNode.workflows.trigger` with the `sendKnockNotification` function, passing the `recipients` and notification data to simplify and standardize the notification process.…nt updates