### PR TITLE
fix: update NotificationMenu to retrieve user email from localStorage

### DIFF
--- a/src/components/notifications/NotificationMenu.tsx
+++ b/src/components/notifications/NotificationMenu.tsx
@@ -14,6 +14,14 @@ import "@knocklabs/react/dist/index.css";
 import useUserStore from "@/stores/useUser";
 
 const NotificationMenu = () => {
+  const [userEmail, setUserEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const email = localStorage.getItem("email") || "iespinosas1700@alumno.ipn.mx";
+      setUserEmail(email);
+    }
+  }, []);
   const [isVisible, setIsVisible] = useState(false);
   const notifButtonRef = useRef(null);
 
@@ -23,13 +31,13 @@ const NotificationMenu = () => {
 
   useEffect(() => {
     setIsClient(true);
-  }, []);
+  }, [userDetails]);
 
   return (
     isClient ? (
     <KnockProvider
       apiKey={process.env.NEXT_PUBLIC_KNOCK_PUBLIC_API_KEY || ""}
-      userId={"iespinosas1700@alumno.ipn.mx"}
+      userId={userEmail || "iespinosas1700@alumno.ipn.mx"}
       i18n={{
         translations: {
           emptyFeedTitle: "No tienes notificaciones aún",


### PR DESCRIPTION
This pull request includes changes to the `NotificationMenu` component in `src/components/notifications/NotificationMenu.tsx` to improve user email handling and reactivity. The most important changes include adding a state for the user's email, updating the effect to set the email from local storage, and modifying the `KnockProvider` to use the state email.

Improvements to user email handling:

* [`src/components/notifications/NotificationMenu.tsx`](diffhunk://#diff-8ac86eb7ee0c512738738662a871b4fc08b8235564bb6188da09c58076e731f1R17-R24): Added a `userEmail` state and an effect to set the email from local storage.

Reactivity updates:

* [`src/components/notifications/NotificationMenu.tsx`](diffhunk://#diff-8ac86eb7ee0c512738738662a871b4fc08b8235564bb6188da09c58076e731f1L26-R40): Updated the effect dependency array to include `userDetails`.
* [`src/components/notifications/NotificationMenu.tsx`](diffhunk://#diff-8ac86eb7ee0c512738738662a871b4fc08b8235564bb6188da09c58076e731f1L26-R40): Modified the `KnockProvider` to use the `userEmail` state.